### PR TITLE
feat: permanent skip for reviewers + anonymize speaker identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,160 @@
+# AGENTS.md - GopherCon Africa Website
+
+## Project Overview
+
+GopherCon Africa conference website built with Next.js 16 (App Router), TypeScript, Prisma (PostgreSQL), Tailwind CSS v4, and NextAuth. Deployed on Vercel.
+
+## Build / Dev / Lint Commands
+
+```bash
+npm run dev          # Start dev server (next dev)
+npm run build        # Production build (prisma generate + next build --webpack)
+npm run lint         # ESLint (next lint)
+npm run start        # Start production server
+npm run postinstall  # prisma generate (runs automatically)
+```
+
+**No test framework is configured.** No test files exist in the project.
+
+### Prisma
+
+```bash
+npx prisma generate          # Regenerate client (output: src/generated/prisma)
+npx prisma migrate dev        # Run migrations in dev
+npx prisma db push            # Push schema without migration
+```
+
+Schema: `prisma/schema.prisma`. Client output: `src/generated/prisma/`.
+
+## Project Structure
+
+```
+src/
+  app/              # Next.js App Router pages and API routes
+    api/            # Route handlers (GET/POST with NextRequest/NextResponse)
+    [year]/         # Dynamic year routes
+    admin/          # Admin dashboard
+  actions/          # Server Actions ('use server')
+  components/       # React components (organized by feature: hero/, header/, footer/, etc.)
+  data/             # Static data
+  db/               # Prisma client singleton + queries/
+  generated/        # Prisma generated client (DO NOT EDIT)
+  lib/              # Shared utilities (auth, config, email, otp, prisma)
+  notification/     # Email templates
+  pages/            # Page-level components (not Next.js pages dir)
+  styles/           # Global CSS
+  types/            # TypeScript type definitions
+  utils/            # Utility functions
+  path.ts           # Centralized route paths
+prisma/
+  schema.prisma     # Database schema
+  migrations/       # Migration files
+```
+
+## Path Aliases (tsconfig.json)
+
+```
+@/*           → ./*
+@components/* → ./src/components/*
+@app/*        → ./src/app/*
+@actions/*    → ./src/actions/*
+@data/*       → ./src/data/*
+@types/*      → ./src/types/*
+@lib/*        → ./src/lib/*
+@utils/*      → ./src/utils/*
+@hooks/*      → ./src/hooks/*
+@styles/*     → ./src/styles/*
+@assets/*     → ./src/assets/*
+@config/*     → ./src/config/*
+@db/*         → ./prisma/*
+@pages/*      → ./src/pages/*
+@path         → ./src/path
+```
+
+Use these aliases consistently. Prefer `@components/...` over relative `../components/...`.
+
+## Code Style
+
+### TypeScript
+
+- **Strict mode** enabled. Do not use `as any`, `@ts-ignore`, or `@ts-expect-error`.
+- Use explicit interface/type definitions in `src/types/` for shared types.
+- Use `camelCase` for variables/functions, `PascalCase` for components/interfaces/types.
+- Prisma model field names use `PascalCase` for booleans (`IsAccepted`, `IsPendingReview`) - follow this existing convention.
+
+### Components
+
+- One component per file. File name matches component name in PascalCase (`Hero.tsx`, `Footer.tsx`).
+- Default exports for page components and layout components.
+- Named exports for server actions and utilities.
+- Mark client components with `'use client'` directive at top of file.
+- Use `lucide-react` for icons, `framer-motion` for animations.
+- UI library: `@heroui/react`. Use it for UI primitives where applicable.
+
+### Styling
+
+- **Tailwind CSS v4** via PostCSS (`@tailwindcss/postcss`). No `tailwind.config` file - uses CSS-based config.
+- Global styles in `src/styles/globals.css` and `src/app/globals.css`.
+- Inline Tailwind classes on elements. No CSS modules.
+
+### Server Actions
+
+- Place in `src/actions/` with `'use server'` directive.
+- Validate input with **Zod** schemas defined in the same file.
+- Return `{ errors: { field?: string[] } }` shape for form validation.
+- Re-export from `src/actions/index.ts` barrel file.
+
+### API Routes
+
+- Use Next.js App Router route handlers in `src/app/api/`.
+- Use `NextRequest`/`NextResponse` from `next/server`.
+- Authenticate with `getToken` from `next-auth/jwt`.
+- Validate request body with Zod.
+- Return JSON responses with appropriate HTTP status codes.
+- Log errors with `console.error` including the route path.
+
+### Database
+
+- Two Prisma client singletons exist: `src/db/index.ts` (exports `db` and default) and `src/lib/prisma.ts` (exports `prisma`). Prefer `import { db } from '@/src/db'` or `import db from '@/src/db'`.
+- Database queries go in `src/db/queries/`.
+- Always use the global singleton pattern to prevent connection exhaustion in dev.
+
+### Auth
+
+- NextAuth v4 with JWT strategy and OTP-based credentials provider.
+- Auth config in `src/lib/auth.ts`.
+- Protected routes check `getToken()` for `email` and `role`.
+- Roles: `admin`, `reviewer`.
+
+### Error Handling
+
+- Server actions: return error objects, don't throw.
+- API routes: try/catch with `console.error` and JSON error response.
+- Use `instanceof Error` checks in catch blocks.
+
+### Imports Order
+
+1. External packages (`react`, `next`, `next-auth`, `zod`, etc.)
+2. Path-aliased internal imports (`@components/...`, `@/src/...`)
+3. Relative imports (only when alias doesn't exist)
+
+### Forms
+
+- Use `react-hook-form` with `@hookform/resolvers` and `zod`/`yup` for validation.
+- Toast notifications via `sonner` (configured in `src/app/providers.tsx`).
+
+## Environment Variables
+
+See `.env.example`. Required:
+- `DATABASE_URL` - PostgreSQL connection string
+- `RESEND_API_KEY` - Email service
+- `REVIEWER_EMAILS`, `ADMIN_EMAILS` - Auth role assignment
+- `NEXTAUTH_SECRET`, `NEXTAUTH_URL` - NextAuth config
+
+## Known Issues
+
+- Build config disables ESLint during build (`.eslintrc.build.json` turns off all rules).
+
+## Deployment
+
+Vercel. CI deploys on GitHub release via `.github/workflows/deploy.yml`. Build command: `npm run build`.

--- a/prisma/migrations/20260313000000_initial_schema/migration.sql
+++ b/prisma/migrations/20260313000000_initial_schema/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT,
+    "published" BOOLEAN NOT NULL DEFAULT false,
+    "authorId" INTEGER,
+
+    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Talk" (
+    "id" TEXT NOT NULL,
+    "fullName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT NOT NULL,
+    "company" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "bio" TEXT NOT NULL,
+    "talkTitle" TEXT NOT NULL,
+    "talkDescription" TEXT NOT NULL,
+    "talkCategory" TEXT NOT NULL DEFAULT '',
+    "talkDuration" TEXT NOT NULL,
+    "talkLevel" TEXT NOT NULL,
+    "previousSpeakingExperience" TEXT NOT NULL,
+    "additionalNotes" TEXT NOT NULL,
+    "eventYear" TEXT NOT NULL,
+    "IsAccepted" BOOLEAN NOT NULL,
+    "IsPendingReview" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Talk_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260316000000_add_review_skipped_field/migration.sql
+++ b/prisma/migrations/20260316000000_add_review_skipped_field/migration.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "Review" ALTER COLUMN "rating" DROP NOT NULL;
+
+ALTER TABLE "Review" ADD COLUMN "skipped" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "Review" ADD CONSTRAINT "review_rating_skipped_check"
+  CHECK (
+    ("skipped" = true AND "rating" IS NULL) OR
+    ("skipped" = false AND "rating" IS NOT NULL)
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,8 +65,9 @@ model Review {
   id            String   @id @default(cuid())
   talkId        String
   reviewerEmail String
-  rating        Float
+  rating        Float?
   notes         String
+  skipped       Boolean  @default(false)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
   talk          Talk     @relation(fields: [talkId], references: [id])

--- a/src/actions/call-for-speakers/create.ts
+++ b/src/actions/call-for-speakers/create.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import type { Talk } from '@/src/generated/prisma';
 import { db } from '@/src/db';
 import { revalidatePath } from 'next/cache';
-import { sendEmail } from '@/src/lib/email';
 import paths from '@path';
 import { Resend } from "resend";
 import { EmailTemplate } from "@/src/notification/email/templates/talk-submission-success";
@@ -131,7 +130,7 @@ export async function createTalk(formState: TalkFormState, formData: FormData): 
         from: "hello@gophercon.africa",
         replyTo: "hello@gophercon.africa",
         to:  validatedFields.data.email,
-        subject: 'Thank you for submitting your talk to the Gophers Conference 2025',
+        subject: 'Thank you for submitting your talk to GopherCon Africa 2026',
         react: EmailTemplate({ firstName: validatedFields.data.fullName })
     });
 

--- a/src/actions/call-for-speakers/create.ts
+++ b/src/actions/call-for-speakers/create.ts
@@ -130,7 +130,7 @@ export async function createTalk(formState: TalkFormState, formData: FormData): 
         from: "hello@gophercon.africa",
         replyTo: "hello@gophercon.africa",
         to:  validatedFields.data.email,
-        subject: 'Thank you for submitting your talk to GopherCon Africa 2026',
+        subject: 'Thank you for submitting your talk to Gophers Conference 2026',
         react: EmailTemplate({ firstName: validatedFields.data.fullName })
     });
 

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -32,11 +32,11 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Count reviewed (has at least one review) — done directly in the DB
+    // Count reviewed (has at least one non-skipped review) — done directly in the DB
     const reviewed = await db.talk.count({
       where: {
         eventYear: currentYear,
-        reviews: { some: {} },
+        reviews: { some: { skipped: false } },
       },
     });
 

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -9,6 +9,7 @@ interface AdminSubmission {
   talkCategory: string;
   averageRating: number | null;
   reviewCount: number;
+  skippedCount: number;
 }
 
 // GET /api/admin/submissions - Fetch all submissions with review aggregation
@@ -35,16 +36,18 @@ export async function GET(request: NextRequest) {
         talkTitle: true,
         fullName: true,
         talkCategory: true,
-        _count: { select: { reviews: true } },
-        reviews: { select: { rating: true } },
+        _count: { select: { reviews: { where: { skipped: false } } } },
+        reviews: { select: { rating: true, skipped: true } },
       },
     });
 
     const submissions: AdminSubmission[] = talks.map((talk) => {
-      const reviewCount = talk._count.reviews;
+      const ratedReviews = talk.reviews.filter((r) => !r.skipped && r.rating !== null);
+      const skippedCount = talk.reviews.filter((r) => r.skipped).length;
+      const reviewCount = ratedReviews.length;
       const averageRating =
         reviewCount > 0
-          ? talk.reviews.reduce((sum, r) => sum + r.rating, 0) / reviewCount
+          ? ratedReviews.reduce((sum, r) => sum + (r.rating ?? 0), 0) / reviewCount
           : null;
       return {
         id: talk.id,
@@ -53,6 +56,7 @@ export async function GET(request: NextRequest) {
         talkCategory: talk.talkCategory,
         averageRating,
         reviewCount,
+        skippedCount,
       };
     });
 

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -5,9 +5,13 @@ import db from '@/src/db';
 
 const reviewSchema = z.object({
   talkId: z.string().cuid(),
-  rating: z.number().min(0.5).max(5).multipleOf(0.5),
+  rating: z.number().min(0.5).max(5).multipleOf(0.5).nullable().optional(),
   notes: z.string().max(5000).optional().default(''),
-});
+  skipped: z.boolean().optional().default(false),
+}).refine(
+  (data) => data.skipped || (data.rating !== null && data.rating !== undefined),
+  { message: 'Rating is required when not skipping', path: ['rating'] }
+);
 
 export async function GET(request: NextRequest) {
   const token = await getToken({ req: request });
@@ -28,10 +32,25 @@ export async function GET(request: NextRequest) {
         eventYear: currentYear,
         IsPendingReview: true,
       },
-      include: {
+      select: {
+        id: true,
+        talkTitle: true,
+        talkDescription: true,
+        talkCategory: true,
+        talkLevel: true,
+        talkDuration: true,
+        bio: true,
+        previousSpeakingExperience: true,
+        additionalNotes: true,
         reviews: {
           where: {
             reviewerEmail: (token.email as string).toLowerCase(),
+          },
+          select: {
+            id: true,
+            rating: true,
+            notes: true,
+            skipped: true,
           },
         },
       },
@@ -68,8 +87,30 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { talkId, rating, notes } = result.data;
+    const { talkId, rating, notes, skipped } = result.data;
     const reviewerEmail = (token.email as string).toLowerCase();
+    const currentYear = new Date().getFullYear().toString();
+
+    const talk = await db.talk.findFirst({
+      where: { id: talkId, eventYear: currentYear, IsPendingReview: true },
+      select: { id: true },
+    });
+
+    if (!talk) {
+      return NextResponse.json({ error: 'Talk not found or not reviewable' }, { status: 404 });
+    }
+
+    const existing = await db.review.findUnique({
+      where: { talkId_reviewerEmail: { talkId, reviewerEmail } },
+      select: { skipped: true },
+    });
+
+    if (existing?.skipped) {
+      return NextResponse.json(
+        { error: 'This talk has been permanently skipped and cannot be changed' },
+        { status: 409 }
+      );
+    }
 
     const review = await db.review.upsert({
       where: {
@@ -79,15 +120,17 @@ export async function POST(request: NextRequest) {
         },
       },
       update: {
-        rating,
+        rating: skipped ? null : rating,
         notes,
+        skipped,
         updatedAt: new Date(),
       },
       create: {
         talkId,
         reviewerEmail,
-        rating,
+        rating: skipped ? null : rating,
         notes,
+        skipped,
       },
     });
 

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -39,9 +39,7 @@ export async function GET(request: NextRequest) {
         talkCategory: true,
         talkLevel: true,
         talkDuration: true,
-        bio: true,
         previousSpeakingExperience: true,
-        additionalNotes: true,
         reviews: {
           where: {
             reviewerEmail: (token.email as string).toLowerCase(),

--- a/src/app/reviews/[talkId]/page.tsx
+++ b/src/app/reviews/[talkId]/page.tsx
@@ -14,12 +14,12 @@ import {
   ArrowLeft,
   List,
   Keyboard,
+  SkipForward,
+  Ban,
 } from 'lucide-react';
 
 interface Talk {
   id: string;
-  fullName: string;
-  email: string;
   talkTitle: string;
   talkDescription: string;
   talkCategory: string;
@@ -27,14 +27,16 @@ interface Talk {
   talkDuration: string;
   bio: string;
   previousSpeakingExperience: string;
+  additionalNotes: string;
   reviews: Array<{
     id: string;
-    rating: number;
+    rating: number | null;
     notes: string;
+    skipped: boolean;
   }>;
 }
 
-type FilterType = 'all' | 'reviewed' | 'pending';
+type FilterType = 'all' | 'reviewed' | 'pending' | 'skipped';
 
 export default function ReviewWorkspacePage() {
   const params = useParams<{ talkId: string }>();
@@ -51,15 +53,22 @@ export default function ReviewWorkspacePage() {
 
   const currentTalkId = params?.talkId;
 
-  const reviewedTalks = talks.filter((t) => t.reviews.length > 0);
+  const reviewedTalks = talks.filter((t) => t.reviews.length > 0 && !t.reviews[0].skipped);
+  const skippedTalks = talks.filter((t) => t.reviews.length > 0 && t.reviews[0].skipped);
   const pendingTalks = talks.filter((t) => t.reviews.length === 0);
 
   const filteredTalks =
-    filter === 'all' ? talks : filter === 'reviewed' ? reviewedTalks : pendingTalks;
+    filter === 'all'
+      ? talks
+      : filter === 'reviewed'
+        ? reviewedTalks
+        : filter === 'skipped'
+          ? skippedTalks
+          : pendingTalks;
 
   const currentTalk = talks.find((t) => t.id === currentTalkId) || null;
   const progressPercentage =
-    talks.length > 0 ? Math.round((reviewedTalks.length / talks.length) * 100) : 0;
+    talks.length > 0 ? Math.round(((reviewedTalks.length + skippedTalks.length) / talks.length) * 100) : 0;
 
   useEffect(() => {
     loadTalks();
@@ -102,6 +111,8 @@ export default function ReviewWorkspacePage() {
     [currentTalkId]
   );
 
+  const isCurrentTalkSkipped = currentTalk?.reviews[0]?.skipped ?? false;
+
   const handleSkip = useCallback(() => {
     const next = findNextUnreviewed(talks);
     if (next) {
@@ -112,9 +123,57 @@ export default function ReviewWorkspacePage() {
     }
   }, [findNextUnreviewed, talks, navigateToTalk, router]);
 
+  const handlePermanentSkip = useCallback(async () => {
+    if (!currentTalk) return;
+
+    setSaving(true);
+    try {
+      const res = await fetch('/api/reviews', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          talkId: currentTalk.id,
+          skipped: true,
+          notes,
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to save skip');
+
+      toast.success('Talk permanently skipped');
+
+      const updatedTalks = talks.map((t) => {
+        if (t.id === currentTalk.id) {
+          return {
+            ...t,
+            reviews: [{ id: 'temp-' + Date.now(), rating: null, notes, skipped: true }],
+          };
+        }
+        return t;
+      });
+
+      setTalks(updatedTalks);
+
+      const next = updatedTalks.find(
+        (t) => t.reviews.length === 0 && t.id !== currentTalk.id
+      );
+      if (next) {
+        navigateToTalk(next.id);
+      } else {
+        toast.success('All talks reviewed!');
+        router.push('/reviews');
+      }
+    } catch (error) {
+      toast.error('Failed to skip talk');
+      console.error(error);
+    } finally {
+      setSaving(false);
+    }
+  }, [currentTalk, notes, talks, navigateToTalk, router]);
+
   const saveReview = useCallback(async () => {
-    if (!currentTalk || rating === 0) {
-      toast.error('Please select a rating');
+    if (!currentTalk || rating === 0 || isCurrentTalkSkipped) {
+      if (!isCurrentTalkSkipped) toast.error('Please select a rating');
       return;
     }
 
@@ -138,7 +197,7 @@ export default function ReviewWorkspacePage() {
         if (t.id === currentTalk.id) {
           return {
             ...t,
-            reviews: [{ id: 'temp-' + Date.now(), rating, notes }],
+            reviews: [{ id: 'temp-' + Date.now(), rating, notes, skipped: false }],
           };
         }
         return t;
@@ -177,18 +236,20 @@ export default function ReviewWorkspacePage() {
 
       switch (e.key) {
         case 's':
+          if (isCurrentTalkSkipped) return;
           e.preventDefault();
           notesTextareaRef.current?.focus();
           break;
         case 'Enter':
           e.preventDefault();
-          if (!saving) saveReview();
+          if (!saving && !isCurrentTalkSkipped) saveReview();
           break;
         case '1':
         case '2':
         case '3':
         case '4':
         case '5':
+          if (isCurrentTalkSkipped) return;
           e.preventDefault();
           setRating(parseInt(e.key, 10));
           break;
@@ -213,7 +274,7 @@ export default function ReviewWorkspacePage() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [currentTalkId, filteredTalks, saving, saveReview, navigateToTalk]);
+  }, [currentTalkId, filteredTalks, saving, saveReview, navigateToTalk, isCurrentTalkSkipped]);
 
   if (loading) {
     return (
@@ -269,7 +330,7 @@ export default function ReviewWorkspacePage() {
               <div className="flex items-center justify-between mb-1">
                 <span className="text-sm font-semibold text-gray-900">Review Progress</span>
                 <span className="text-sm text-gray-500 font-medium">
-                  {reviewedTalks.length} / {talks.length} ({progressPercentage}%)
+                  {reviewedTalks.length + skippedTalks.length} / {talks.length} ({progressPercentage}%)
                 </span>
               </div>
               <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
@@ -316,10 +377,9 @@ export default function ReviewWorkspacePage() {
           <div className="flex-1 flex flex-col max-w-4xl mx-auto w-full">
             <div className="p-6 md:p-8 flex-1">
               <div className="mb-6">
-                <h1 className="text-2xl font-bold text-gray-900 leading-tight mb-2">
+                <h1 className="text-2xl font-bold text-gray-900 leading-tight">
                   {currentTalk.talkTitle}
                 </h1>
-                <p className="text-lg text-gray-600 font-medium">{currentTalk.fullName}</p>
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
@@ -381,12 +441,23 @@ export default function ReviewWorkspacePage() {
                     {currentTalk.previousSpeakingExperience}
                   </div>
                 </div>
+
+                {currentTalk.additionalNotes && (
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                      Additional Notes
+                    </h3>
+                    <div className="bg-amber-50 rounded-lg p-4 border border-amber-100 whitespace-pre-wrap text-gray-700">
+                      {currentTalk.additionalNotes}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
 
 
             <div className="bg-gray-50 border-t border-gray-200 p-6 md:p-8 shrink-0">
-              <div className="mb-6">
+              <div className={`mb-6 ${isCurrentTalkSkipped ? 'opacity-50 pointer-events-none' : ''}`}>
                 <StarRating
                   value={rating}
                   name="rating"
@@ -412,21 +483,32 @@ export default function ReviewWorkspacePage() {
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}
                   rows={3}
-                  className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:border-[#006B3F] focus:ring-2 focus:ring-[#006B3F]/20 focus:outline-none transition-shadow bg-white resize-y"
-                  placeholder="Add your thoughts here... (Press 's' to focus)"
+                  disabled={isCurrentTalkSkipped}
+                  className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:border-[#006B3F] focus:ring-2 focus:ring-[#006B3F]/20 focus:outline-none transition-shadow bg-white resize-y disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-50"
+                  placeholder={isCurrentTalkSkipped ? 'This talk has been permanently skipped' : "Add your thoughts here... (Press 's' to focus)"}
                 />
               </div>
 
               <div className="flex flex-col-reverse sm:flex-row items-center justify-between gap-4">
-                <button
-                  onClick={handleSkip}
-                  className="w-full sm:w-auto px-6 py-2.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 hover:bg-gray-50 hover:text-gray-900 rounded-lg transition-colors focus:ring-2 focus:ring-[#006B3F] focus:outline-none"
-                >
-                  Skip for now
-                </button>
+                <div className="flex gap-2 w-full sm:w-auto">
+                  <button
+                    onClick={handleSkip}
+                    className="flex-1 sm:flex-none px-4 py-2.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 hover:bg-gray-50 hover:text-gray-900 rounded-lg transition-colors focus:ring-2 focus:ring-[#006B3F] focus:outline-none"
+                  >
+                    Skip for now
+                  </button>
+                  <button
+                    onClick={handlePermanentSkip}
+                    disabled={saving || isCurrentTalkSkipped}
+                    className="flex-1 sm:flex-none inline-flex items-center justify-center gap-1.5 px-4 py-2.5 text-sm font-medium text-orange-700 bg-orange-50 border border-orange-200 hover:bg-orange-100 rounded-lg disabled:opacity-60 disabled:cursor-not-allowed transition-colors focus:ring-2 focus:ring-orange-400 focus:outline-none"
+                  >
+                    <SkipForward className="w-4 h-4" />
+                    {isCurrentTalkSkipped ? 'Skipped' : 'Permanently Skip'}
+                  </button>
+                </div>
                 <button
                   onClick={saveReview}
-                  disabled={saving || rating === 0}
+                  disabled={saving || rating === 0 || isCurrentTalkSkipped}
                   className="w-full sm:w-auto flex items-center justify-center gap-2 px-8 py-2.5 text-sm font-medium text-white bg-[#006B3F] hover:bg-[#008751] rounded-lg disabled:opacity-60 disabled:cursor-not-allowed transition-colors focus:ring-2 focus:ring-[#006B3F] focus:ring-offset-2 focus:outline-none shadow-sm"
                 >
                   {saving ? 'Saving...' : 'Save & Next'}
@@ -439,7 +521,7 @@ export default function ReviewWorkspacePage() {
 
         <div className="w-full md:w-80 lg:w-96 shrink-0 bg-gray-50 border-t md:border-t-0 md:border-l border-gray-200 flex flex-col h-64 md:h-auto">
           <div className="flex items-center p-2 bg-gray-100/50 border-b border-gray-200 shrink-0">
-            {(['all', 'pending', 'reviewed'] as FilterType[]).map((f) => (
+            {(['all', 'pending', 'reviewed', 'skipped'] as FilterType[]).map((f) => (
               <button
                 key={f}
                 onClick={() => setFilter(f)}
@@ -454,7 +536,9 @@ export default function ReviewWorkspacePage() {
                   ? talks.length
                   : f === 'pending'
                     ? pendingTalks.length
-                    : reviewedTalks.length}
+                    : f === 'skipped'
+                      ? skippedTalks.length
+                      : reviewedTalks.length}
                 )
               </button>
             ))}
@@ -470,7 +554,8 @@ export default function ReviewWorkspacePage() {
               filteredTalks.map((talk) => {
                 const isSelected = talk.id === currentTalkId;
                 const review = talk.reviews[0];
-                const isReviewed = !!review;
+                const isReviewed = !!review && !review.skipped;
+                const isSkipped = !!review && review.skipped;
 
                 return (
                   <button
@@ -490,17 +575,21 @@ export default function ReviewWorkspacePage() {
                       >
                         {talk.talkTitle}
                       </h4>
-                      {isReviewed ? (
+                      {isSkipped ? (
+                        <div className="flex items-center gap-1 bg-gray-50 text-gray-500 px-1.5 py-0.5 rounded text-xs font-bold border border-gray-200 shrink-0">
+                          <Ban className="w-3 h-3" />
+                          <span>Skipped</span>
+                        </div>
+                      ) : isReviewed ? (
                         <div className="flex items-center gap-1 bg-green-50 text-green-700 px-1.5 py-0.5 rounded text-xs font-bold border border-green-100 shrink-0">
                           <Star className="w-3 h-3 fill-current" />
-                          <span>{review.rating.toFixed(1)}</span>
+                          <span>{review.rating?.toFixed(1)}</span>
                         </div>
                       ) : (
                         <Circle className="w-2.5 h-2.5 text-yellow-500 fill-yellow-500 mt-1 shrink-0" />
                       )}
                     </div>
                     <div className="flex items-center justify-between">
-                      <p className="text-xs text-gray-500 truncate pr-2">{talk.fullName}</p>
                       {isSelected && (
                         <span className="text-[10px] font-bold uppercase text-[#006B3F] tracking-wider shrink-0">
                           Selected

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -3,12 +3,10 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { Star } from 'lucide-react';
+import { Star, Ban } from 'lucide-react';
 
 interface Talk {
   id: string;
-  fullName: string;
-  email: string;
   talkTitle: string;
   talkDescription: string;
   talkCategory: string;
@@ -18,8 +16,9 @@ interface Talk {
   previousSpeakingExperience: string;
   reviews: Array<{
     id: string;
-    rating: number;
+    rating: number | null;
     notes: string;
+    skipped: boolean;
   }>;
 }
 
@@ -46,8 +45,10 @@ export default function ReviewsPage() {
     }
   }
 
-  const reviewedCount = talks.filter(t => t.reviews.length > 0).length;
-  const progressPercentage = talks.length > 0 ? Math.round((reviewedCount / talks.length) * 100) : 0;
+  const reviewedCount = talks.filter(t => t.reviews.length > 0 && !t.reviews[0].skipped).length;
+  const skippedCount = talks.filter(t => t.reviews.length > 0 && t.reviews[0].skipped).length;
+  const completedCount = reviewedCount + skippedCount;
+  const progressPercentage = talks.length > 0 ? Math.round((completedCount / talks.length) * 100) : 0;
 
   if (loading) {
     return (
@@ -66,7 +67,7 @@ export default function ReviewsPage() {
             <div className="flex-1 max-w-md">
               <div className="flex items-center justify-between mb-1">
                 <span className="text-sm text-gray-600">
-                  Progress: {reviewedCount}/{talks.length} reviewed
+                  Progress: {completedCount}/{talks.length} reviewed
                 </span>
                 <span className="text-sm font-medium text-gray-700">{progressPercentage}%</span>
               </div>
@@ -90,7 +91,6 @@ export default function ReviewsPage() {
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Speaker</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Level</th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
@@ -99,7 +99,8 @@ export default function ReviewsPage() {
               <tbody className="divide-y divide-gray-200">
                 {talks.map((talk) => {
                   const review = talk.reviews[0];
-                  const reviewed = !!review;
+                  const reviewed = !!review && !review.skipped;
+                  const skipped = !!review && review.skipped;
                   return (
                     <tr
                       key={talk.id}
@@ -109,14 +110,18 @@ export default function ReviewsPage() {
                       <td className="px-6 py-4">
                         <p className="font-medium text-gray-900">{talk.talkTitle}</p>
                       </td>
-                      <td className="px-6 py-4 text-gray-600">{talk.fullName}</td>
                       <td className="px-6 py-4 text-gray-600">{talk.talkCategory}</td>
                       <td className="px-6 py-4 text-gray-600">{talk.talkLevel}</td>
                       <td className="px-6 py-4">
-                        {reviewed ? (
+                        {skipped ? (
+                          <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                            <Ban className="w-3 h-3" />
+                            Skipped
+                          </span>
+                        ) : reviewed ? (
                           <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
                             <Star className="w-3 h-3 fill-current" />
-                            {review.rating.toFixed(1)}
+                            {review.rating?.toFixed(1)}
                           </span>
                         ) : (
                           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -67,7 +67,7 @@ export default function ReviewsPage() {
             <div className="flex-1 max-w-md">
               <div className="flex items-center justify-between mb-1">
                 <span className="text-sm text-gray-600">
-                  Progress: {completedCount}/{talks.length} reviewed
+                  Progress: {completedCount}/{talks.length} completed
                 </span>
                 <span className="text-sm font-medium text-gray-700">{progressPercentage}%</span>
               </div>

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -2,32 +2,23 @@ export interface ReviewData {
   id: string;
   talkId: string;
   reviewerEmail: string;
-  rating: number;
+  rating: number | null;
   notes: string;
+  skipped: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export interface TalkWithReview {
   id: string;
-  fullName: string;
-  email: string;
-  phone: string;
-  company: string;
-  title: string;
-  bio: string;
   talkTitle: string;
   talkDescription: string;
   talkCategory: string;
   talkDuration: string;
   talkLevel: string;
+  bio: string;
   previousSpeakingExperience: string;
   additionalNotes: string;
-  eventYear: string;
-  IsAccepted: boolean;
-  IsPendingReview: boolean;
-  createdAt: Date;
-  updatedAt: Date;
   reviews: ReviewData[];
 }
 


### PR DESCRIPTION
## Summary

- **Permanent Skip**: Reviewers can permanently skip talks (e.g. their own submission) with an optional note. Skip is enforced server-side and irreversible.
- **Anonymized Reviews**: Speaker name, email, and phone removed from the review UI to reduce reviewer bias.
- **Admin Accuracy**: Skipped reviews excluded from average rating calculations and reviewed counts. Admins see `skippedCount` per talk.
- **Bug Fix**: CFP confirmation email subject corrected from "Gophers Conference 2025" → "GopherCon Africa 2026".

## Screenshots

<!-- Add screenshots here -->

### Reviewer — Skip button & locked state
<img width="1161" height="694" alt="Screenshot 2026-04-22 at 02 21 01" src="https://github.com/user-attachments/assets/e06a8eba-d0c6-44be-bcfe-3cd95e93d721" />


### Reviewer — Anonymized talk list
<img width="1377" height="444" alt="Screenshot 2026-04-22 at 02 20 40" src="https://github.com/user-attachments/assets/f37b05d9-bf95-4cfb-8dc2-fd9b5d28c1dd" />


### Admin — Submissions with skip counts
<img width="1430" height="753" alt="Screenshot 2026-04-22 at 02 20 27" src="https://github.com/user-attachments/assets/71f75356-8ac6-45d6-b992-fe97447fb8e9" />


## Schema Changes

- `Review.rating`: `Float` → `Float?` (nullable for skipped reviews)
- `Review.skipped`: new `Boolean @default(false)`
- DB check constraint: `(skipped=true AND rating IS NULL) OR (skipped=false AND rating IS NOT NULL)`

## Release Strategy

### ⚠️ Pre-deploy (REQUIRED)

Run against the **production database** before deploying:

```bash
npx prisma migrate resolve --applied 20260313000000_initial_schema
```

This marks the baseline migration (User/Post/Talk tables) as already applied, since those tables were created via `db push`.

### Deploy

Once the resolve command succeeds, deploy normally. `prisma migrate deploy` in CI will apply `20260316000000_add_review_skipped_field` which adds the `skipped` column, makes `rating` nullable, and adds the check constraint.

### Post-deploy

No additional steps. Existing reviews default to `skipped: false` with their ratings intact.

### Rollback

If needed, revert the deploy and run:
```sql
ALTER TABLE "Review" DROP CONSTRAINT IF EXISTS "review_skip_rating_check";
ALTER TABLE "Review" DROP COLUMN IF EXISTS "skipped";
ALTER TABLE "Review" ALTER COLUMN "rating" SET NOT NULL;
```