### PR TITLE
ci: add temporary Vercel auth debug step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install -g vercel@41.6.1
+      - name: Debug Vercel auth
+        run: |
+          echo "VERCEL_ORG_ID length: ${#VERCEL_ORG_ID}"
+          echo "VERCEL_PROJECT_ID length: ${#VERCEL_PROJECT_ID}"
+          echo "--- whoami ---"
+          vercel whoami --token=${{ secrets.VERCEL_TOKEN }}
+          echo "--- teams ls ---"
+          vercel teams ls --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build project


### PR DESCRIPTION
Print whoami and teams ls output to identify whether the GitHub-secret token is scoped to the correct team. To be removed once the deploy succeeds.