### PR TITLE
ci: track Vercel CLI latest and drop debug step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,15 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Vercel CLI
-        run: npm install -g vercel@41.6.1
-      - name: Debug Vercel auth
-        run: |
-          echo "VERCEL_ORG_ID length: ${#VERCEL_ORG_ID}"
-          echo "VERCEL_PROJECT_ID length: ${#VERCEL_PROJECT_ID}"
-          echo "--- whoami ---"
-          vercel whoami --token=${{ secrets.VERCEL_TOKEN }}
-          echo "--- teams ls ---"
-          vercel teams ls --token=${{ secrets.VERCEL_TOKEN }}
+        run: npm install -g vercel@latest
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build project


### PR DESCRIPTION
Vercel's deploy endpoint now requires CLI 47.2.2+, so pinning to 41.6.1 breaks uploads. Switch to vercel@latest and remove the temporary auth debug step now that token scope is confirmed working.