### PR TITLE
ci: run prisma migrate deploy before each build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
         run: npm install -g vercel@latest
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Run database migrations
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
       - name: Build project
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel


### PR DESCRIPTION
## Summary

- Adds a `Run database migrations` step to the deploy workflow that runs `prisma migrate deploy` before each Vercel build
- Fixes `/api/admin/stats` and `/api/admin/submissions` returning 500s in production — both routes filter on `Review.skipped` which was never added to the live DB because the CI had no migration step
- Migration `20260316_add_review_skipped_field` (adds `skipped` column, makes `rating` nullable) is the specific one that needs to land

## Pre-requisite

Add `DATABASE_URL` as a GitHub Actions secret (repo Settings → Secrets → Actions) before merging. Without it the migration step will fail.

## Manual unblock (do this now)

Run the missing migration against production immediately to fix the live site without waiting for this PR:

```bash
DATABASE_URL="<prod-db-url>" npx prisma migrate deploy
```

## Test plan

- [ ] Add `DATABASE_URL` GitHub Actions secret
- [ ] Merge and confirm deploy workflow completes the migration step without error
- [ ] Verify `/api/admin/stats` and `/api/admin/submissions` return 200 in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)