### PR TITLE
ci: pin prisma CLI to v5 for migrate deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Run database migrations
-        run: npx prisma migrate deploy
+        run: npx prisma@5 migrate deploy
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
       - name: Build project


### PR DESCRIPTION
## What happened

The previous deploy ([run 26419733481](https://github.com/gophercon-africa/website/actions/runs/26419733481/job/77771794299)) failed because `npx prisma migrate deploy` downloaded Prisma **7.8.0** (latest), which dropped support for the `url = env(...)` syntax in `schema.prisma`. The project uses Prisma 5.

## Fix

Pin to `npx prisma@5 migrate deploy` so CI uses a version compatible with the existing schema format.

## Test plan

- [ ] Merge and confirm the migration step completes without error
- [ ] Confirm `/api/admin/stats` and `/api/admin/submissions` return 200 in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)