### PR TITLE
fix: include bio and additionalNotes in reviews API select

### DIFF
--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -39,6 +39,8 @@ export async function GET(request: NextRequest) {
         talkCategory: true,
         talkLevel: true,
         talkDuration: true,
+        bio: true,
+        additionalNotes: true,
         previousSpeakingExperience: true,
         reviews: {
           where: {


### PR DESCRIPTION
## Summary
- The `GET /api/reviews` Prisma `select` was missing `bio` and `additionalNotes` fields
- This caused the Speaker Bio and Additional Notes sections on the review page (`/reviews/[talkId]`) to always render empty
- Fix adds both fields to the select so they're returned from the API

## Test plan
- [ ] Log in as a reviewer and open a talk in the review workspace
- [ ] Confirm the Speaker Bio section now shows the submitted bio text
- [ ] Confirm the Additional Notes section appears when a talk has notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)