### PR TITLE
Admin submission review: search/filter, detail view, decisions, CSV export

### DIFF
--- a/prisma/migrations/20260616100610_add_talk_decision_notes/migration.sql
+++ b/prisma/migrations/20260616100610_add_talk_decision_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Talk" ADD COLUMN     "decisionNotes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Talk {
   eventYear                  String
   IsAccepted                 Boolean
   IsPendingReview            Boolean
+  decisionNotes              String?
   createdAt                  DateTime @default(now())
   updatedAt                  DateTime @updatedAt
   reviews                    Review[]

--- a/src/app/admin/_components/AdminSubmissionsTable.tsx
+++ b/src/app/admin/_components/AdminSubmissionsTable.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Download } from 'lucide-react';
+import Modal from '@/src/components/common/Modal';
+import { toCsv, downloadCsv } from '@/src/lib/csv';
+import type { AdminSubmission } from '@/src/types/admin';
+
+type StatusFilter = 'all' | 'pending' | 'accepted' | 'rejected';
+
+const STATUS_LABELS: Record<AdminSubmission['status'], string> = {
+  pending: 'Pending',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+};
+
+const STATUS_BADGE_CLASSES: Record<AdminSubmission['status'], string> = {
+  pending: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  accepted: 'bg-green-50 text-green-700 border-green-200',
+  rejected: 'bg-red-50 text-red-700 border-red-200',
+};
+
+const EXPORT_COLUMNS: { key: string; label: string }[] = [
+  { key: 'email', label: 'Email' },
+  { key: 'talkTitle', label: 'Talk Title' },
+  { key: 'fullName', label: 'Speaker Name' },
+  { key: 'talkCategory', label: 'Category' },
+  { key: 'status', label: 'Status' },
+  { key: 'averageRating', label: 'Average Rating' },
+  { key: 'reviewCount', label: 'Review Count' },
+];
+
+const DEFAULT_EXPORT_COLUMNS = new Set(['email']);
+
+export function AdminSubmissionsTable({ submissions }: { submissions: AdminSubmission[] }) {
+  const router = useRouter();
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [exportColumns, setExportColumns] = useState<Set<string>>(new Set(DEFAULT_EXPORT_COLUMNS));
+  const [duplicateModalSubmission, setDuplicateModalSubmission] = useState<AdminSubmission | null>(null);
+
+  const filteredSubmissions = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return submissions.filter((s) => {
+      if (statusFilter !== 'all' && s.status !== statusFilter) return false;
+      if (!query) return true;
+      return (
+        s.fullName.toLowerCase().includes(query) ||
+        s.email.toLowerCase().includes(query) ||
+        s.talkTitle.toLowerCase().includes(query)
+      );
+    });
+  }, [submissions, search, statusFilter]);
+
+  function updateSearch(value: string) {
+    setSearch(value);
+    setSelectedIds(new Set());
+  }
+
+  function updateStatusFilter(value: StatusFilter) {
+    setStatusFilter(value);
+    setSelectedIds(new Set());
+  }
+
+  function toggleRow(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAllFiltered() {
+    const filteredIds = filteredSubmissions.map((s) => s.id);
+    const allSelected = filteredIds.every((id) => selectedIds.has(id));
+    setSelectedIds(allSelected ? new Set() : new Set(filteredIds));
+  }
+
+  function toggleExportColumn(key: string) {
+    setExportColumns((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function exportRows(rows: AdminSubmission[], filename: string) {
+    const columns = EXPORT_COLUMNS.filter((c) => exportColumns.has(c.key));
+    const csvRows = rows.map((s) => ({
+      talkTitle: s.talkTitle,
+      fullName: s.fullName,
+      email: s.email,
+      talkCategory: s.talkCategory,
+      status: STATUS_LABELS[s.status],
+      averageRating: s.averageRating !== null ? s.averageRating.toFixed(1) : '',
+      reviewCount: s.reviewCount,
+    }));
+    const csv = toCsv(csvRows, columns.map((c) => c.key));
+    downloadCsv(filename, csv);
+  }
+
+  const allFilteredSelected =
+    filteredSubmissions.length > 0 && filteredSubmissions.every((s) => selectedIds.has(s.id));
+  const selectedSubmissions = submissions.filter((s) => selectedIds.has(s.id));
+
+  return (
+    <div className="bg-white rounded-lg shadow overflow-hidden mt-8">
+      <div className="px-6 py-4 border-b border-gray-200 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900">Submissions Overview</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => updateSearch(e.target.value)}
+            placeholder="Search by name, email, or title..."
+            className="text-sm rounded-lg border border-gray-300 px-3 py-1.5 focus:border-[#006B3F] focus:ring-2 focus:ring-[#006B3F]/20 focus:outline-none w-full sm:w-64"
+          />
+          <select
+            value={statusFilter}
+            onChange={(e) => updateStatusFilter(e.target.value as StatusFilter)}
+            className="text-sm rounded-lg border border-gray-300 px-3 py-1.5 focus:border-[#006B3F] focus:ring-2 focus:ring-[#006B3F]/20 focus:outline-none"
+          >
+            <option value="all">All statuses</option>
+            <option value="pending">Pending</option>
+            <option value="accepted">Accepted</option>
+            <option value="rejected">Rejected</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="px-6 py-3 border-b border-gray-200 flex flex-wrap items-center gap-4">
+        <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+          Export columns:
+        </span>
+        {EXPORT_COLUMNS.map((col) => (
+          <label key={col.key} className="flex items-center gap-1.5 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={exportColumns.has(col.key)}
+              onChange={() => toggleExportColumn(col.key)}
+              className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+            />
+            {col.label}
+          </label>
+        ))}
+        <div className="flex-1" />
+        <button
+          onClick={() => exportRows(filteredSubmissions, 'submissions-filtered.csv')}
+          disabled={filteredSubmissions.length === 0}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[#006B3F] bg-[#006B3F]/5 hover:bg-[#006B3F]/10 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <Download className="w-4 h-4" />
+          Export filtered ({filteredSubmissions.length})
+        </button>
+        <button
+          onClick={() => exportRows(selectedSubmissions, 'submissions-selected.csv')}
+          disabled={selectedSubmissions.length === 0}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-[#006B3F] bg-[#006B3F]/5 hover:bg-[#006B3F]/10 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <Download className="w-4 h-4" />
+          Export selected ({selectedSubmissions.length})
+        </button>
+      </div>
+
+      {filteredSubmissions.length === 0 ? (
+        <div className="p-8 text-center text-gray-500">No submissions found</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="px-4 py-3 w-10">
+                  <input
+                    type="checkbox"
+                    checked={allFilteredSelected}
+                    onChange={toggleSelectAllFiltered}
+                    className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+                    aria-label="Select all filtered submissions"
+                  />
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Title</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Speaker</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg Rating</th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Reviews</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {filteredSubmissions.map((submission) => (
+                <tr
+                  key={submission.id}
+                  className="hover:bg-gray-50 transition-colors cursor-pointer"
+                  onClick={() => router.push(`/admin/submissions/${submission.id}`)}
+                >
+                  <td className="px-4 py-4 w-10" onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(submission.id)}
+                      onChange={() => toggleRow(submission.id)}
+                      className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+                      aria-label={`Select ${submission.talkTitle}`}
+                    />
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{submission.talkTitle}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    <div className="flex items-center gap-2">
+                      <span>{submission.fullName}</span>
+                      {submission.duplicateCount > 1 && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (submission.duplicateTalks.length === 1) {
+                              router.push(`/admin/submissions/${submission.duplicateTalks[0].id}`);
+                            } else {
+                              setDuplicateModalSubmission(submission);
+                            }
+                          }}
+                          title={`Also submitted: ${submission.duplicateTalks.map((t) => t.talkTitle).join(', ')}`}
+                          className="px-1.5 py-0.5 rounded text-xs font-bold border bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100 transition-colors"
+                        >
+                          ×{submission.duplicateCount}
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{submission.talkCategory}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium border ${STATUS_BADGE_CLASSES[submission.status]}`}>
+                      {STATUS_LABELS[submission.status]}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    {submission.averageRating !== null ? submission.averageRating.toFixed(1) : '—'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{submission.reviewCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Modal
+        isOpen={!!duplicateModalSubmission}
+        onClose={() => setDuplicateModalSubmission(null)}
+        title={`Other submissions by ${duplicateModalSubmission?.fullName ?? ''}`}
+        size="sm"
+      >
+        <ul className="space-y-2">
+          {duplicateModalSubmission?.duplicateTalks.map((t) => (
+            <li key={t.id}>
+              <button
+                onClick={() => {
+                  setDuplicateModalSubmission(null);
+                  router.push(`/admin/submissions/${t.id}`);
+                }}
+                className="text-sm text-[#006B3F] hover:underline text-left"
+              >
+                {t.talkTitle}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,30 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-
-interface AdminStats {
-  total: number;
-  pending: number;
-  reviewed: number;
-  accepted: number;
-  rejected: number;
-}
-
-interface ReviewerProgress {
-  reviewerEmail: string;
-  reviewsCompleted: number;
-  totalSubmissions: number;
-  percentageComplete: number;
-}
-
-interface AdminSubmission {
-  id: string;
-  talkTitle: string;
-  fullName: string;
-  talkCategory: string;
-  averageRating: number | null;
-  reviewCount: number;
-}
+import { AdminSubmissionsTable } from '@/src/app/admin/_components/AdminSubmissionsTable';
+import type { AdminStats, ReviewerProgress, AdminSubmission } from '@/src/types/admin';
 
 export default function AdminDashboardPage() {
   const [stats, setStats] = useState<AdminStats | null>(null);
@@ -174,43 +152,7 @@ export default function AdminDashboardPage() {
           )}
         </div>
 
-        <div className="bg-white rounded-lg shadow overflow-hidden mt-8">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h2 className="text-lg font-semibold text-gray-900">Submissions Overview</h2>
-          </div>
-          {submissions.length === 0 ? (
-            <div className="p-8 text-center text-gray-500">
-              No submissions found
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Title</th>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Speaker</th>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg Rating</th>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Reviews</th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {submissions.map((submission) => (
-                    <tr key={submission.id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{submission.talkTitle}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{submission.fullName}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{submission.talkCategory}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                        {submission.averageRating !== null ? submission.averageRating.toFixed(1) : '—'}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{submission.reviewCount}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
+        <AdminSubmissionsTable submissions={submissions} />
       </div>
     </div>
   );

--- a/src/app/admin/submissions/[id]/page.tsx
+++ b/src/app/admin/submissions/[id]/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { StarRating } from '@/src/components/common/StarRating';
+import { ArrowLeft, BookOpen, Award, Clock, List, Ban } from 'lucide-react';
+import type { AdminSubmissionDetail, AdminReview } from '@/src/types/admin';
+
+type Status = AdminSubmissionDetail['status'];
+
+const STATUS_LABELS: Record<Status, string> = {
+  pending: 'Pending',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+};
+
+export default function AdminSubmissionDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const [submission, setSubmission] = useState<AdminSubmissionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<Status>('pending');
+  const [decisionNotes, setDecisionNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const id = params?.id;
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/submissions/${id}`);
+      if (!res.ok) throw new Error('Failed to load submission');
+      const data: AdminSubmissionDetail = await res.json();
+      setSubmission(data);
+      setStatus(data.status);
+      setDecisionNotes(data.decisionNotes ?? '');
+    } catch (error) {
+      toast.error('Failed to load submission');
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function saveDecision() {
+    if (!id) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/submissions/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, decisionNotes }),
+      });
+      if (!res.ok) throw new Error('Failed to save decision');
+      toast.success('Decision saved');
+      await load();
+    } catch (error) {
+      toast.error('Failed to save decision');
+      console.error(error);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[calc(100vh-80px)] flex items-center justify-center bg-gray-50">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-8 h-8 border-4 border-[#006B3F]/20 border-t-[#006B3F] rounded-full animate-spin" />
+          <p className="text-gray-500 font-medium">Loading submission...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!submission) {
+    return (
+      <div className="min-h-[calc(100vh-80px)] flex items-center justify-center bg-gray-50 p-4">
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center max-w-md w-full">
+          <List className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Submission Not Found</h2>
+          <button
+            onClick={() => router.push('/admin')}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-[#006B3F] hover:bg-[#006B3F]/5 rounded-lg transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to dashboard
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b border-gray-200">
+        <div className="px-4 sm:px-6 py-3 max-w-6xl mx-auto">
+          <button
+            onClick={() => router.push('/admin')}
+            className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to dashboard
+          </button>
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto p-4 sm:p-6 flex flex-col md:flex-row gap-6">
+        <div className="flex-1 bg-white rounded-lg shadow-sm border border-gray-200 p-6 md:p-8">
+          <h1 className="text-2xl font-bold text-gray-900 leading-tight mb-1">{submission.talkTitle}</h1>
+          <p className="text-sm text-gray-500 mb-6">
+            {submission.fullName} &lt;{submission.email}&gt; · {submission.company} · {submission.phone}
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+            <div className="bg-gray-50 rounded-lg p-3 border border-gray-100 flex items-start gap-3">
+              <BookOpen className="w-5 h-5 text-[#006B3F] shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-0.5">Category</p>
+                <p className="text-sm font-medium text-gray-900">{submission.talkCategory}</p>
+              </div>
+            </div>
+            <div className="bg-gray-50 rounded-lg p-3 border border-gray-100 flex items-start gap-3">
+              <Award className="w-5 h-5 text-[#006B3F] shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-0.5">Level</p>
+                <p className="text-sm font-medium text-gray-900">{submission.talkLevel}</p>
+              </div>
+            </div>
+            <div className="bg-gray-50 rounded-lg p-3 border border-gray-100 flex items-start gap-3">
+              <Clock className="w-5 h-5 text-[#006B3F] shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-0.5">Duration</p>
+                <p className="text-sm font-medium text-gray-900">{submission.talkDuration}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="prose prose-sm sm:prose-base max-w-none text-gray-700 space-y-6">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Description</h3>
+              <div className="bg-gray-50 rounded-lg p-4 border border-gray-100 whitespace-pre-wrap">
+                {submission.talkDescription}
+              </div>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Speaker Bio</h3>
+              <div className="bg-gray-50 rounded-lg p-4 border border-gray-100 whitespace-pre-wrap">
+                {submission.bio}
+              </div>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Previous Experience</h3>
+              <div className="bg-gray-50 rounded-lg p-4 border border-gray-100 whitespace-pre-wrap">
+                {submission.previousSpeakingExperience}
+              </div>
+            </div>
+            {submission.additionalNotes && (
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">Additional Notes</h3>
+                <div className="bg-amber-50 rounded-lg p-4 border border-amber-100 whitespace-pre-wrap text-gray-700">
+                  {submission.additionalNotes}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="w-full md:w-96 shrink-0 flex flex-col gap-6">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-5">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3">
+              Reviews ({submission.reviewCount}
+              {submission.averageRating !== null ? `, avg ${submission.averageRating.toFixed(1)}` : ''})
+            </h3>
+            {submission.reviews.length === 0 ? (
+              <p className="text-sm text-gray-500">No reviews yet.</p>
+            ) : (
+              <ul className="space-y-4">
+                {submission.reviews.map((review: AdminReview) => (
+                  <li key={review.id} className="border-b border-gray-100 pb-3 last:border-0 last:pb-0">
+                    <p className="text-sm font-medium text-gray-900 mb-1">{review.reviewerEmail}</p>
+                    {review.skipped ? (
+                      <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                        <Ban className="w-3.5 h-3.5" />
+                        Skipped{review.skipReason ? `: ${review.skipReason}` : ''}
+                      </div>
+                    ) : (
+                      <StarRating value={review.rating ?? 0} name={`rating-${review.id}`} onChange={() => {}} readonly />
+                    )}
+                    {review.notes && (
+                      <p className="text-sm text-gray-600 mt-2 whitespace-pre-wrap">{review.notes}</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-5">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3">Decision</h3>
+            <div className="flex gap-2 mb-4">
+              {(['pending', 'accepted', 'rejected'] as Status[]).map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setStatus(s)}
+                  className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                    status === s
+                      ? 'bg-[#006B3F] text-white border-[#006B3F]'
+                      : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                  }`}
+                >
+                  {STATUS_LABELS[s]}
+                </button>
+              ))}
+            </div>
+            <label htmlFor="decision-notes" className="block text-sm font-medium text-gray-700 mb-1">
+              Decision Notes
+            </label>
+            <textarea
+              id="decision-notes"
+              value={decisionNotes}
+              onChange={(e) => setDecisionNotes(e.target.value)}
+              rows={4}
+              placeholder="Optional notes about this decision..."
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:border-[#006B3F] focus:ring-2 focus:ring-[#006B3F]/20 focus:outline-none transition-shadow bg-white resize-y mb-4"
+            />
+            <button
+              onClick={saveDecision}
+              disabled={saving}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-[#006B3F] hover:bg-[#008751] rounded-lg disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              {saving ? 'Saving...' : 'Save Decision'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/progress/route.ts
+++ b/src/app/api/admin/progress/route.ts
@@ -20,12 +20,11 @@ export async function GET(request: NextRequest) {
   try {
     const currentYear = new Date().getFullYear().toString();
 
-    // Get total submissions for current year
+    // Get total submissions for current year (independent of decision status,
+    // so a talk being accepted/rejected mid-cycle doesn't shrink the denominator
+    // below a reviewer's already-recorded review count)
     const totalSubmissions = await db.talk.count({
-      where: {
-        eventYear: currentYear,
-        IsPendingReview: true,
-      },
+      where: { eventYear: currentYear },
     });
 
     // Get all reviewers (combine REVIEWER_EMAILS and ADMIN_EMAILS, deduplicated)

--- a/src/app/api/admin/submissions/[id]/route.ts
+++ b/src/app/api/admin/submissions/[id]/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { z } from 'zod';
+import { db } from '@/src/db';
+import { getTalkStatus, statusToBooleans } from '@/src/lib/talkStatus';
+import { computeReviewStats } from '@/src/lib/reviewStats';
+import type { AdminSubmissionDetail } from '@/src/types/admin';
+
+const patchSchema = z.object({
+  status: z.enum(['pending', 'accepted', 'rejected']),
+  decisionNotes: z.string().max(5000).optional().nullable(),
+});
+
+async function requireAdmin(request: NextRequest) {
+  const token = await getToken({ req: request });
+
+  if (!token?.email) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const userRole = token.role as string | undefined;
+  if (userRole !== 'admin') {
+    return { error: NextResponse.json({ error: 'Forbidden - Admin only' }, { status: 403 }) };
+  }
+
+  return { token };
+}
+
+// GET /api/admin/submissions/[id] - Fetch a single submission with all reviews
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const { id } = await params;
+    const currentYear = new Date().getFullYear().toString();
+
+    const talk = await db.talk.findFirst({
+      where: { id, eventYear: currentYear },
+      select: {
+        id: true,
+        fullName: true,
+        email: true,
+        phone: true,
+        company: true,
+        title: true,
+        bio: true,
+        talkTitle: true,
+        talkDescription: true,
+        talkCategory: true,
+        talkDuration: true,
+        talkLevel: true,
+        previousSpeakingExperience: true,
+        additionalNotes: true,
+        IsAccepted: true,
+        IsPendingReview: true,
+        decisionNotes: true,
+        reviews: {
+          select: {
+            id: true,
+            reviewerEmail: true,
+            rating: true,
+            notes: true,
+            skipped: true,
+            skipReason: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+
+    if (!talk) {
+      return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
+    }
+
+    const { averageRating, reviewCount } = computeReviewStats(talk.reviews);
+
+    const detail: AdminSubmissionDetail = {
+      id: talk.id,
+      fullName: talk.fullName,
+      email: talk.email,
+      phone: talk.phone,
+      company: talk.company,
+      title: talk.title,
+      bio: talk.bio,
+      talkTitle: talk.talkTitle,
+      talkDescription: talk.talkDescription,
+      talkCategory: talk.talkCategory,
+      talkDuration: talk.talkDuration,
+      talkLevel: talk.talkLevel,
+      previousSpeakingExperience: talk.previousSpeakingExperience,
+      additionalNotes: talk.additionalNotes,
+      status: getTalkStatus(talk),
+      decisionNotes: talk.decisionNotes,
+      averageRating,
+      reviewCount,
+      reviews: talk.reviews.map((r) => ({
+        ...r,
+        updatedAt: r.updatedAt.toISOString(),
+      })),
+    };
+
+    return NextResponse.json(detail);
+  } catch (error) {
+    console.error('GET /api/admin/submissions/[id] error:', error);
+    return NextResponse.json({ error: 'Failed to fetch submission' }, { status: 500 });
+  }
+}
+
+// PATCH /api/admin/submissions/[id] - Update a submission's decision status/notes
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAdmin(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const result = patchSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: result.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { status, decisionNotes } = result.data;
+    const currentYear = new Date().getFullYear().toString();
+
+    const existing = await db.talk.findFirst({
+      where: { id, eventYear: currentYear },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Submission not found' }, { status: 404 });
+    }
+
+    const talk = await db.talk.update({
+      where: { id },
+      data: {
+        ...statusToBooleans(status),
+        decisionNotes: decisionNotes ?? null,
+      },
+    });
+
+    return NextResponse.json({ success: true, talk });
+  } catch (error) {
+    console.error('PATCH /api/admin/submissions/[id] error:', error);
+    return NextResponse.json({ error: 'Failed to update submission' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { db } from '@/src/db';
-
-interface AdminSubmission {
-  id: string;
-  talkTitle: string;
-  fullName: string;
-  talkCategory: string;
-  averageRating: number | null;
-  reviewCount: number;
-  skippedCount: number;
-}
+import { getTalkStatus } from '@/src/lib/talkStatus';
+import { computeReviewStats } from '@/src/lib/reviewStats';
+import type { AdminSubmission } from '@/src/types/admin';
 
 // GET /api/admin/submissions - Fetch all submissions with review aggregation
 export async function GET(request: NextRequest) {
@@ -35,33 +28,44 @@ export async function GET(request: NextRequest) {
         id: true,
         talkTitle: true,
         fullName: true,
+        email: true,
         talkCategory: true,
-        _count: { select: { reviews: { where: { skipped: false } } } },
+        IsAccepted: true,
+        IsPendingReview: true,
         reviews: { select: { rating: true, skipped: true } },
       },
     });
 
+    // Group talks by case-insensitive email to detect repeat submitters
+    const talksByEmail = new Map<string, { id: string; talkTitle: string }[]>();
+    for (const talk of talks) {
+      const key = talk.email.toLowerCase().trim();
+      const group = talksByEmail.get(key) ?? [];
+      group.push({ id: talk.id, talkTitle: talk.talkTitle });
+      talksByEmail.set(key, group);
+    }
+
     const submissions: AdminSubmission[] = talks.map((talk) => {
-      const ratedReviews = talk.reviews.filter((r) => !r.skipped && r.rating !== null);
-      const skippedCount = talk.reviews.filter((r) => r.skipped).length;
-      const reviewCount = ratedReviews.length;
-      const averageRating =
-        reviewCount > 0
-          ? ratedReviews.reduce((sum, r) => sum + (r.rating ?? 0), 0) / reviewCount
-          : null;
+      const { averageRating, reviewCount, skippedCount } = computeReviewStats(talk.reviews);
+      const group = talksByEmail.get(talk.email.toLowerCase().trim()) ?? [];
+
       return {
         id: talk.id,
         talkTitle: talk.talkTitle,
         fullName: talk.fullName,
+        email: talk.email,
         talkCategory: talk.talkCategory,
+        status: getTalkStatus(talk),
         averageRating,
         reviewCount,
         skippedCount,
+        duplicateCount: group.length,
+        duplicateTalks: group.filter((t) => t.id !== talk.id),
       };
     });
 
     // Sort by reviewCount desc, then averageRating desc as tiebreaker
-    submissions.sort((a, b) => 
+    submissions.sort((a, b) =>
       b.reviewCount - a.reviewCount || (b.averageRating ?? 0) - (a.averageRating ?? 0)
     );
 

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -35,6 +35,7 @@ export async function GET(request: NextRequest) {
       },
       select: {
         id: true,
+        email: true,
         talkTitle: true,
         talkDescription: true,
         talkCategory: true,
@@ -58,7 +59,31 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'desc' },
     });
 
-    return NextResponse.json(talks);
+    // Same-author detection (by email) across all of this year's talks, not just
+    // this reviewer's pending queue, so siblings already decided still surface.
+    // The author's name/email itself is never sent to the client — only sibling
+    // talk titles — to preserve the existing blind-review anonymization.
+    const allTalksThisYear = await db.talk.findMany({
+      where: { eventYear: currentYear },
+      select: { id: true, email: true, talkTitle: true },
+    });
+
+    const talksByEmail = new Map<string, { id: string; talkTitle: string }[]>();
+    for (const talk of allTalksThisYear) {
+      const key = talk.email.toLowerCase().trim();
+      const group = talksByEmail.get(key) ?? [];
+      group.push({ id: talk.id, talkTitle: talk.talkTitle });
+      talksByEmail.set(key, group);
+    }
+
+    const response = talks.map(({ email, ...talk }) => {
+      const siblings = (talksByEmail.get(email.toLowerCase().trim()) ?? []).filter(
+        (t) => t.id !== talk.id
+      );
+      return { ...talk, otherSubmissionsByAuthor: siblings };
+    });
+
+    return NextResponse.json(response);
   } catch (error) {
     console.error('GET /api/reviews error:', error);
     return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 500 });

--- a/src/app/reviews/[talkId]/page.tsx
+++ b/src/app/reviews/[talkId]/page.tsx
@@ -18,6 +18,7 @@ import {
   SkipForward,
   Ban,
   ExternalLink,
+  Users,
 } from 'lucide-react';
 
 interface Talk {
@@ -30,6 +31,7 @@ interface Talk {
   bio: string;
   previousSpeakingExperience: string;
   additionalNotes: string;
+  otherSubmissionsByAuthor: Array<{ id: string; talkTitle: string }>;
   reviews: Array<{
     id: string;
     rating: number | null;
@@ -468,6 +470,42 @@ export default function ReviewWorkspacePage() {
                     </h3>
                     <div className="bg-amber-50 rounded-lg p-4 border border-amber-100 whitespace-pre-wrap text-gray-700">
                       {currentTalk.additionalNotes}
+                    </div>
+                  </div>
+                )}
+
+                {currentTalk.otherSubmissionsByAuthor.length > 0 && (
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2 flex items-center gap-2">
+                      <Users className="w-4 h-4 text-[#006B3F]" />
+                      Other Submissions by This Author
+                    </h3>
+                    <div className="bg-blue-50 rounded-lg p-4 border border-blue-100 text-gray-700">
+                      <p className="text-sm text-gray-500 mb-2">
+                        This author also submitted{' '}
+                        {currentTalk.otherSubmissionsByAuthor.length === 1 ? 'this talk' : 'these talks'} this year:
+                      </p>
+                      <ul className="list-disc list-inside space-y-1 text-sm">
+                        {currentTalk.otherSubmissionsByAuthor.map((t) => {
+                          const isNavigable = talks.some((talk) => talk.id === t.id);
+                          return (
+                            <li key={t.id}>
+                              {isNavigable ? (
+                                <button
+                                  onClick={() => navigateToTalk(t.id)}
+                                  className="text-[#006B3F] hover:underline text-left"
+                                >
+                                  {t.talkTitle}
+                                </button>
+                              ) : (
+                                <span className="text-gray-500">
+                                  {t.talkTitle} <span className="text-xs">(already decided)</span>
+                                </span>
+                              )}
+                            </li>
+                          );
+                        })}
+                      </ul>
                     </div>
                   </div>
                 )}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,25 @@
+function escapeCsvValue(value: string | number | null): string {
+  const str = value === null ? '' : String(value);
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function toCsv(rows: Record<string, string | number | null>[], columns: string[]): string {
+  const header = columns.map(escapeCsvValue).join(',');
+  const lines = rows.map((row) => columns.map((col) => escapeCsvValue(row[col] ?? null)).join(','));
+  return [header, ...lines].join('\n');
+}
+
+export function downloadCsv(filename: string, csvContent: string): void {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/reviewStats.ts
+++ b/src/lib/reviewStats.ts
@@ -1,0 +1,18 @@
+interface ReviewLike {
+  rating: number | null;
+  skipped: boolean;
+}
+
+export function computeReviewStats(reviews: ReviewLike[]): {
+  averageRating: number | null;
+  reviewCount: number;
+  skippedCount: number;
+} {
+  const ratedReviews = reviews.filter((r) => !r.skipped && r.rating !== null);
+  const skippedCount = reviews.filter((r) => r.skipped).length;
+  const reviewCount = ratedReviews.length;
+  const averageRating =
+    reviewCount > 0 ? ratedReviews.reduce((sum, r) => sum + (r.rating ?? 0), 0) / reviewCount : null;
+
+  return { averageRating, reviewCount, skippedCount };
+}

--- a/src/lib/talkStatus.ts
+++ b/src/lib/talkStatus.ts
@@ -1,0 +1,17 @@
+export type TalkStatus = 'pending' | 'accepted' | 'rejected';
+
+export function getTalkStatus(talk: { IsPendingReview: boolean; IsAccepted: boolean }): TalkStatus {
+  if (talk.IsPendingReview) return 'pending';
+  return talk.IsAccepted ? 'accepted' : 'rejected';
+}
+
+export function statusToBooleans(status: TalkStatus): { IsPendingReview: boolean; IsAccepted: boolean } {
+  switch (status) {
+    case 'pending':
+      return { IsPendingReview: true, IsAccepted: false };
+    case 'accepted':
+      return { IsPendingReview: false, IsAccepted: true };
+    case 'rejected':
+      return { IsPendingReview: false, IsAccepted: false };
+  }
+}

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,9 +1,57 @@
+import type { TalkStatus } from '@/src/lib/talkStatus';
+
 export interface AdminStats {
   total: number;
   pending: number;
   reviewed: number;
   accepted: number;
   rejected: number;
+}
+
+export interface AdminSubmission {
+  id: string;
+  talkTitle: string;
+  fullName: string;
+  email: string;
+  talkCategory: string;
+  status: TalkStatus;
+  averageRating: number | null;
+  reviewCount: number;
+  skippedCount: number;
+  duplicateCount: number;
+  duplicateTalks: { id: string; talkTitle: string }[];
+}
+
+export interface AdminReview {
+  id: string;
+  reviewerEmail: string;
+  rating: number | null;
+  notes: string;
+  skipped: boolean;
+  skipReason: string | null;
+  updatedAt: string;
+}
+
+export interface AdminSubmissionDetail {
+  id: string;
+  fullName: string;
+  email: string;
+  phone: string;
+  company: string;
+  title: string;
+  bio: string;
+  talkTitle: string;
+  talkDescription: string;
+  talkCategory: string;
+  talkDuration: string;
+  talkLevel: string;
+  previousSpeakingExperience: string;
+  additionalNotes: string;
+  status: TalkStatus;
+  decisionNotes: string | null;
+  averageRating: number | null;
+  reviewCount: number;
+  reviews: AdminReview[];
 }
 
 export interface ReviewerProgress {


### PR DESCRIPTION
## Summary
- Admin dashboard: searchable/filterable submissions table (status, name/email/title search), per-row + select-all checkboxes, and CSV export with a dynamic column picker (email pre-selected by default) for either the filtered set or a selected subset
- New admin submission detail page (`/admin/submissions/[id]`): shows full talk info, every reviewer's rating/notes, and lets the admin accept/reject/keep-pending with a free-text `decisionNotes` field
- Same-author repeat-submission detection (case-insensitive email match, scoped to the current event year): clickable badge in the admin table linking to sibling submissions
- Reviewer-facing detail page now shows a "Other Submissions by This Author" section — sibling talk titles only (no name/email, preserving blind review), clickable when the sibling is still in the reviewer's queue, plain text with "(already decided)" otherwise
- Fixed a bug where reviewer progress could show >100% — the denominator only counted talks still pending a decision while the numerator counted all of a reviewer's recorded reviews that year, so decided talks shrank the denominator below the review count

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `next build --webpack` succeeds, all new routes registered
- [x] Manually verified end-to-end against the local dev DB (admin + reviewer OTP login, list/detail/PATCH endpoints, duplicate-author grouping, CSV column defaults, reviewer-progress percentage bounded ≤100%, 403 enforcement for non-admins on the new endpoints) — all test fixtures created during verification were removed afterward
- [ ] Manual click-through in the deployed preview (table search/filter, export, decision save, duplicate badge navigation, reviewer "other submissions" section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)