### PR TITLE
feat: DB-backed admin/reviewer user management UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 # Review Dashboard Auth
+# These only seed the AuthorizedUser table the first time /admin/users is loaded
+# (if it's still empty). After that, manage reviewer/admin access in the UI at /admin/users.
 REVIEWER_EMAILS="reviewer1@example.com,reviewer2@example.com"
 ADMIN_EMAILS="admin@example.com"
 OTP_EXPIRY_MINUTES="10"

--- a/prisma/migrations/20260617000100_add_authorized_user/migration.sql
+++ b/prisma/migrations/20260617000100_add_authorized_user/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "AuthorizedUser" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "isReviewer" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AuthorizedUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthorizedUser_email_key" ON "AuthorizedUser"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,3 +76,12 @@ model Review {
 
   @@unique([talkId, reviewerEmail])
 }
+
+model AuthorizedUser {
+  id         String   @id @default(cuid())
+  email      String   @unique
+  isAdmin    Boolean  @default(false)
+  isReviewer Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+}

--- a/src/actions/auth/otp.ts
+++ b/src/actions/auth/otp.ts
@@ -4,7 +4,8 @@ import { z } from 'zod';
 import { db } from '@/src/db';
 import { Resend } from 'resend';
 import { generateOtp, hashOtp } from '@/src/lib/otp';
-import { OTP_EXPIRY_MINUTES, getEmailRole } from '@/src/lib/config';
+import { OTP_EXPIRY_MINUTES } from '@/src/lib/config';
+import { getEmailRole } from '@/src/lib/authorizedUsers';
 import { OtpFormState } from '@/src/types/otp';
 import { OtpEmail } from '@/src/notification/email/templates/otp-verification';
 
@@ -24,7 +25,7 @@ export async function sendOtp(_: OtpFormState, formData: FormData): Promise<OtpF
   const { email } = result.data;
   const normalizedEmail = email.toLowerCase().trim();
 
-  const role = getEmailRole(normalizedEmail);
+  const role = await getEmailRole(normalizedEmail);
   if (!role) {
     return { errors: { email: ['Email not authorized'] } };
   }

--- a/src/app/admin/_components/AdminUsersTable.tsx
+++ b/src/app/admin/_components/AdminUsersTable.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import type { AuthorizedUserDto } from '@/src/types/admin';
+
+export function AdminUsersTable({
+  users,
+  onUsersChange,
+}: {
+  users: AuthorizedUserDto[];
+  onUsersChange: (users: AuthorizedUserDto[]) => void;
+}) {
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+
+  async function toggleRole(user: AuthorizedUserDto, role: 'isAdmin' | 'isReviewer') {
+    const nextValue = !user[role];
+    const previousUsers = users;
+
+    onUsersChange(users.map((u) => (u.id === user.id ? { ...u, [role]: nextValue } : u)));
+    setPendingIds((prev) => new Set(prev).add(user.id));
+
+    try {
+      const res = await fetch(`/api/admin/users/${user.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [role]: nextValue }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to update user');
+      }
+    } catch (error) {
+      onUsersChange(previousUsers);
+      toast.error('Failed to update user');
+      console.error(error);
+    } finally {
+      setPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(user.id);
+        return next;
+      });
+    }
+  }
+
+  async function deleteUser(user: AuthorizedUserDto) {
+    if (!window.confirm(`Remove ${user.email}? They will lose admin/reviewer access.`)) {
+      return;
+    }
+
+    const previousUsers = users;
+    onUsersChange(users.filter((u) => u.id !== user.id));
+
+    try {
+      const res = await fetch(`/api/admin/users/${user.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        throw new Error('Failed to delete user');
+      }
+      toast.success(`Removed ${user.email}`);
+    } catch (error) {
+      onUsersChange(previousUsers);
+      toast.error('Failed to delete user');
+      console.error(error);
+    }
+  }
+
+  if (users.length === 0) {
+    return <div className="p-8 text-center text-gray-500">No authorized users yet</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Admin</th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Reviewer</th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"></th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {users.map((user) => (
+            <tr key={user.id} className="hover:bg-gray-50 transition-colors">
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{user.email}</td>
+              <td className="px-6 py-4 whitespace-nowrap">
+                <input
+                  type="checkbox"
+                  checked={user.isAdmin}
+                  disabled={pendingIds.has(user.id)}
+                  onChange={() => toggleRole(user, 'isAdmin')}
+                  className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+                  aria-label={`${user.email} is admin`}
+                />
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap">
+                <input
+                  type="checkbox"
+                  checked={user.isReviewer}
+                  disabled={pendingIds.has(user.id)}
+                  onChange={() => toggleRole(user, 'isReviewer')}
+                  className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+                  aria-label={`${user.email} is reviewer`}
+                />
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-right">
+                <button
+                  onClick={() => deleteUser(user)}
+                  className="text-sm font-medium text-red-600 hover:text-red-700"
+                >
+                  Remove
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/admin/_components/AdminUsersTable.tsx
+++ b/src/app/admin/_components/AdminUsersTable.tsx
@@ -30,6 +30,9 @@ export function AdminUsersTable({
       if (!res.ok) {
         throw new Error('Failed to update user');
       }
+
+      const roleLabel = role === 'isAdmin' ? 'Admin' : 'Reviewer';
+      toast.success(`${user.email} ${nextValue ? 'granted' : 'removed from'} ${roleLabel}`);
     } catch (error) {
       onUsersChange(previousUsers);
       toast.error('Failed to update user');

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { toast } from 'sonner';
 import { AdminSubmissionsTable } from '@/src/app/admin/_components/AdminSubmissionsTable';
 import type { AdminStats, ReviewerProgress, AdminSubmission } from '@/src/types/admin';
@@ -70,9 +71,14 @@ export default function AdminDashboardPage() {
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4">
       <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
-          <p className="text-gray-600 mt-2">Review system statistics and progress</p>
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
+            <p className="text-gray-600 mt-2">Review system statistics and progress</p>
+          </div>
+          <Link href="/admin/users" className="text-sm font-medium text-[#006B3F] hover:underline">
+            Manage Users
+          </Link>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-6 mb-8">

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+import { AdminUsersTable } from '@/src/app/admin/_components/AdminUsersTable';
+import type { AuthorizedUserDto } from '@/src/types/admin';
+
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState<AuthorizedUserDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [email, setEmail] = useState('');
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isReviewer, setIsReviewer] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  async function loadUsers() {
+    try {
+      setLoading(true);
+      const res = await fetch('/api/admin/users');
+      if (!res.ok) throw new Error('Failed to load users');
+      setUsers(await res.json());
+    } catch (error) {
+      toast.error('Failed to load users');
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!email.trim()) {
+      toast.error('Email is required');
+      return;
+    }
+
+    if (!isAdmin && !isReviewer) {
+      toast.error('Select at least one role');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/admin/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), isAdmin, isReviewer }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? 'Failed to add user');
+      }
+
+      const newUser: AuthorizedUserDto = await res.json();
+      setUsers((prev) => [...prev, newUser].sort((a, b) => a.email.localeCompare(b.email)));
+      setEmail('');
+      setIsAdmin(false);
+      setIsReviewer(true);
+      toast.success(`Added ${newUser.email}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to add user');
+      console.error(error);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">Loading users...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Manage Users</h1>
+            <p className="text-gray-600 mt-2">Configure who has reviewer and admin access</p>
+          </div>
+          <Link href="/admin" className="text-sm font-medium text-[#006B3F] hover:underline">
+            Back to dashboard
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-lg shadow overflow-hidden mb-8">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900">Add user</h2>
+          </div>
+          <form onSubmit={handleSubmit} className="px-6 py-4 flex flex-wrap items-end gap-4">
+            <div className="flex-1 min-w-[240px]">
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="name@example.com"
+                className="w-full text-sm rounded-lg border border-gray-300 px-3 py-2 focus:border-[#006B3F] focus:ring-2 focus:ring-[#006B3F]/20 focus:outline-none"
+              />
+            </div>
+            <label className="flex items-center gap-1.5 text-sm text-gray-700 pb-2">
+              <input
+                type="checkbox"
+                checked={isAdmin}
+                onChange={(e) => setIsAdmin(e.target.checked)}
+                className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+              />
+              Admin
+            </label>
+            <label className="flex items-center gap-1.5 text-sm text-gray-700 pb-2">
+              <input
+                type="checkbox"
+                checked={isReviewer}
+                onChange={(e) => setIsReviewer(e.target.checked)}
+                className="rounded border-gray-300 text-[#006B3F] focus:ring-[#006B3F]"
+              />
+              Reviewer
+            </label>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-white bg-[#006B3F] hover:bg-[#005a34] rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Add user
+            </button>
+          </form>
+        </div>
+
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900">Authorized users</h2>
+          </div>
+          <AdminUsersTable users={users} onUsersChange={setUsers} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/progress/route.ts
+++ b/src/app/api/admin/progress/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { db } from '@/src/db';
-import { REVIEWER_EMAILS, ADMIN_EMAILS } from '@/src/lib/config';
+import { listAuthorizedUsers } from '@/src/lib/authorizedUsers';
 import { AdminProgressResponse } from '@/src/types/admin';
 
 // GET /api/admin/progress - Fetch reviewer progress
@@ -27,8 +27,11 @@ export async function GET(request: NextRequest) {
       where: { eventYear: currentYear },
     });
 
-    // Get all reviewers (combine REVIEWER_EMAILS and ADMIN_EMAILS, deduplicated)
-    const allReviewers = [...new Set([...REVIEWER_EMAILS, ...ADMIN_EMAILS])];
+    // Get all reviewers (anyone with the reviewer or admin flag, from the DB)
+    const authorizedUsers = await listAuthorizedUsers();
+    const allReviewers = authorizedUsers
+      .filter((u) => u.isReviewer || u.isAdmin)
+      .map((u) => u.email);
 
     // Single query: count reviews per reviewer for talks in the current year
     const reviewCounts = await db.review.groupBy({

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { z } from 'zod';
+import { db } from '@/src/db';
+
+const updateUserSchema = z.object({
+  isAdmin: z.boolean().optional(),
+  isReviewer: z.boolean().optional(),
+});
+
+// PATCH /api/admin/users/[id] - Update a user's roles
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const token = await getToken({ req: request });
+
+  if (!token?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (token.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden - Admin only' }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const body = await request.json().catch(() => null);
+  const result = updateUserSchema.safeParse(body);
+
+  if (!result.success) {
+    return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+  }
+
+  try {
+    const user = await db.authorizedUser.update({
+      where: { id },
+      data: result.data,
+    });
+    return NextResponse.json(user);
+  } catch (error) {
+    console.error('PATCH /api/admin/users/[id] error:', error);
+    return NextResponse.json({ error: 'Failed to update user' }, { status: 500 });
+  }
+}
+
+// DELETE /api/admin/users/[id] - Remove an authorized user
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const token = await getToken({ req: request });
+
+  if (!token?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (token.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden - Admin only' }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  try {
+    await db.authorizedUser.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('DELETE /api/admin/users/[id] error:', error);
+    return NextResponse.json({ error: 'Failed to delete user' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { z } from 'zod';
+import { db } from '@/src/db';
+import { listAuthorizedUsers } from '@/src/lib/authorizedUsers';
+
+const createUserSchema = z
+  .object({
+    email: z.string().email(),
+    isAdmin: z.boolean().optional().default(false),
+    isReviewer: z.boolean().optional().default(false),
+  })
+  .refine((data) => data.isAdmin || data.isReviewer, {
+    message: 'At least one of isAdmin or isReviewer must be true',
+  });
+
+// GET /api/admin/users - List all authorized users
+export async function GET(request: NextRequest) {
+  const token = await getToken({ req: request });
+
+  if (!token?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (token.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden - Admin only' }, { status: 403 });
+  }
+
+  try {
+    const users = await listAuthorizedUsers();
+    return NextResponse.json(users);
+  } catch (error) {
+    console.error('GET /api/admin/users error:', error);
+    return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 });
+  }
+}
+
+// POST /api/admin/users - Add a new authorized user
+export async function POST(request: NextRequest) {
+  const token = await getToken({ req: request });
+
+  if (!token?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (token.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden - Admin only' }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const result = createUserSchema.safeParse(body);
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 });
+  }
+
+  const email = result.data.email.toLowerCase().trim();
+
+  try {
+    const existing = await db.authorizedUser.findUnique({ where: { email } });
+    if (existing) {
+      return NextResponse.json({ error: 'User already exists' }, { status: 409 });
+    }
+
+    const user = await db.authorizedUser.create({
+      data: { email, isAdmin: result.data.isAdmin, isReviewer: result.data.isReviewer },
+    });
+
+    return NextResponse.json(user, { status: 201 });
+  } catch (error) {
+    console.error('POST /api/admin/users error:', error);
+    return NextResponse.json({ error: 'Failed to create user' }, { status: 500 });
+  }
+}

--- a/src/lib/authorizedUsers.ts
+++ b/src/lib/authorizedUsers.ts
@@ -1,0 +1,61 @@
+import { db } from '@/src/db';
+import { REVIEWER_EMAILS, ADMIN_EMAILS } from '@/src/lib/config';
+import type { AuthorizedUser } from '@/src/generated/prisma';
+
+function getEnvEmailRole(email: string): 'admin' | 'reviewer' | null {
+  if (ADMIN_EMAILS.includes(email)) return 'admin';
+  if (REVIEWER_EMAILS.includes(email)) return 'reviewer';
+  return null;
+}
+
+export async function getEmailRole(email: string): Promise<'admin' | 'reviewer' | null> {
+  const normalized = email.toLowerCase().trim();
+  const user = await db.authorizedUser.findUnique({ where: { email: normalized } });
+
+  if (user) {
+    if (user.isAdmin) return 'admin';
+    if (user.isReviewer) return 'reviewer';
+    return null;
+  }
+
+  return getEnvEmailRole(normalized);
+}
+
+export async function isAuthorizedEmail(email: string): Promise<boolean> {
+  return (await getEmailRole(email)) !== null;
+}
+
+async function seedFromEnv(): Promise<void> {
+  const emails = new Map<string, { isAdmin: boolean; isReviewer: boolean }>();
+
+  for (const email of ADMIN_EMAILS) {
+    emails.set(email, { isAdmin: true, isReviewer: false });
+  }
+  for (const email of REVIEWER_EMAILS) {
+    const existing = emails.get(email);
+    emails.set(email, { isAdmin: existing?.isAdmin ?? false, isReviewer: true });
+  }
+
+  if (emails.size === 0) return;
+
+  await db.$transaction(
+    Array.from(emails.entries()).map(([email, flags]) =>
+      db.authorizedUser.upsert({
+        where: { email },
+        update: {},
+        create: { email, ...flags },
+      })
+    )
+  );
+}
+
+export async function listAuthorizedUsers(): Promise<AuthorizedUser[]> {
+  let users = await db.authorizedUser.findMany({ orderBy: { email: 'asc' } });
+
+  if (users.length === 0 && (ADMIN_EMAILS.length > 0 || REVIEWER_EMAILS.length > 0)) {
+    await seedFromEnv();
+    users = await db.authorizedUser.findMany({ orderBy: { email: 'asc' } });
+  }
+
+  return users;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -26,14 +26,3 @@ export const SESSION_EXPIRY_DAYS = parsePositiveInt(process.env.SESSION_EXPIRY_D
 // set CALL_FOR_SPEAKERS_OPEN=true to reopen.
 export const CALL_FOR_SPEAKERS_OPEN = parseBoolean(process.env.CALL_FOR_SPEAKERS_OPEN, false);
 
-export function isAuthorizedEmail(email: string): boolean {
-  const normalized = email.toLowerCase();
-  return REVIEWER_EMAILS.includes(normalized) || ADMIN_EMAILS.includes(normalized);
-}
-
-export function getEmailRole(email: string): 'reviewer' | 'admin' | null {
-  const normalized = email.toLowerCase();
-  if (ADMIN_EMAILS.includes(normalized)) return 'admin';
-  if (REVIEWER_EMAILS.includes(normalized)) return 'reviewer';
-  return null;
-}

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -65,3 +65,11 @@ export interface AdminProgressResponse {
   reviewers: ReviewerProgress[];
   totalSubmissions: number;
 }
+
+export interface AuthorizedUserDto {
+  id: string;
+  email: string;
+  isAdmin: boolean;
+  isReviewer: boolean;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- Replace the env-var-only (`REVIEWER_EMAILS`/`ADMIN_EMAILS`) reviewer/admin authorization with a new `AuthorizedUser` DB table, manageable from a new `/admin/users` page.
- Role lookups (`getEmailRole`) check the DB first, falling back to the env lists for emails not yet migrated — so existing deployments don't lose access on upgrade.
- The new admin users list auto-seeds from the env lists the first time it's loaded if the table is empty, so the UI starts populated with zero manual steps.
- New `/api/admin/users` (GET/POST) and `/api/admin/users/[id]` (PATCH/DELETE) routes, admin-gated like the existing admin routes.

## Caveats (not blockers, flagging for review)
- Env vars remain a permanent fallback for emails not in the DB — removing a DB row for someone still listed in the env vars will re-grant them access on next login. Happy to make DB authoritative once populated if preferred.
- Role changes don't apply to an already-logged-in user until their session expires (same as the prior env-var behavior — role is baked into the JWT at sign-in).

## Test plan
- [x] `npx tsc --noEmit` and `next build` pass
- [x] Migration applied locally (`prisma migrate deploy`)
- [x] Live end-to-end test with a real admin session cookie: GET (auto-seed), POST, PATCH, DELETE on `/api/admin/users` all verified against local Postgres
- [ ] Manual click-through of `/admin/users` in a browser