### PR TITLE
feat: decouple admin and reviewer access

### DIFF
--- a/src/app/api/admin/progress/route.ts
+++ b/src/app/api/admin/progress/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
     // Get all reviewers (anyone with the reviewer or admin flag, from the DB)
     const authorizedUsers = await listAuthorizedUsers();
     const allReviewers = authorizedUsers
-      .filter((u) => u.isReviewer || u.isAdmin)
+      .filter((u) => u.isReviewer)
       .map((u) => u.email);
 
     // Single query: count reviews per reviewer for talks in the current year

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
   }
 
   const userRole = token.role as string | undefined;
-  if (userRole !== 'reviewer' && userRole !== 'admin') {
+  if (userRole !== 'reviewer' && !token.isReviewer) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest) {
   }
 
   const userRole = token.role as string | undefined;
-  if (userRole !== 'reviewer' && userRole !== 'admin') {
+  if (userRole !== 'reviewer' && !token.isReviewer) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import CredentialsProvider from "next-auth/providers/credentials";
 import db from "@/src/db";
 import { verifyOtp as verifyOtpHash } from "@/src/lib/otp";
-import { SESSION_EXPIRY_DAYS } from "@/src/lib/config";
+import { SESSION_EXPIRY_DAYS, REVIEWER_EMAILS } from "@/src/lib/config";
 
 export const authConfig: NextAuthOptions = {
   adapter: PrismaAdapter(db as never),
@@ -85,14 +85,21 @@ export const authConfig: NextAuthOptions = {
         token.id = user.id;
         token.email = user.email;
         token.role = (user as { role?: string }).role;
+
+        const email = (user.email ?? "").toLowerCase();
+        const dbUser = await db.authorizedUser.findUnique({ where: { email } });
+        // If a DB row exists, use its isReviewer flag directly.
+        // Fall back to env list for emails not yet in the DB.
+        token.isReviewer = dbUser ? dbUser.isReviewer : REVIEWER_EMAILS.includes(email);
       }
       return token;
     },
     async session({ session, token }) {
       if (session.user) {
-        (session.user as { id?: string; email?: string | null; role?: string }).id = token.id as string;
+        session.user.id = token.id;
         session.user.email = token.email as string;
-        (session.user as { role?: string }).role = token.role as string;
+        session.user.role = token.role;
+        session.user.isReviewer = token.isReviewer;
       }
       return session;
     },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -79,9 +79,10 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next()
   }
 
-  // Reviewer routes: require reviewer or admin role
+  // Reviewer routes: require reviewer role or admin-who-is-also-a-reviewer
   if (isReviewerPath(pathname)) {
-    if (role !== 'reviewer' && role !== 'admin') {
+    const isReviewer = token.isReviewer as boolean | undefined
+    if (role !== 'reviewer' && !isReviewer) {
       const loginUrl = new URL('/otp-login', request.url)
       loginUrl.searchParams.set('callbackUrl', pathname)
       return NextResponse.redirect(loginUrl)

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,19 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id?: string;
+      role?: string;
+      isReviewer?: boolean;
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id?: string;
+    role?: string;
+    isReviewer?: boolean;
+  }
+}


### PR DESCRIPTION
## Summary
- Admin role no longer implies reviewer access. Each flag is now independent.
- An admin-only user is blocked from `/reviews` and excluded from the Reviewer Progress table.
- An admin who also has `isReviewer` checked in `/admin/users` retains access to both areas.

## How it works
`isReviewer` is stored as a separate claim in the NextAuth JWT at sign-in (looked up from the `AuthorizedUser` DB row). The proxy and `/api/reviews` gate on that claim rather than `role === 'admin'`.

## Changes
- `src/lib/auth.ts` — set `token.isReviewer` from DB at JWT creation; falls back to env list for not-yet-migrated emails
- `src/types/next-auth.d.ts` — type declarations for the extra JWT/Session fields
- `src/proxy.ts` — reviewer path guard uses `isReviewer` claim instead of `role === 'admin'`
- `src/app/api/reviews/route.ts` — same guard change on GET + POST handlers
- `src/app/api/admin/progress/route.ts` — Reviewer Progress filters on `isReviewer` only

## Test plan
- [ ] Log in as admin-only user → redirected away from `/reviews`, not in Reviewer Progress
- [ ] Log in as admin with `isReviewer` also checked → full access to both `/admin` and `/reviews`
- [ ] Log in as reviewer-only → `/reviews` works, `/admin` blocked as before
- [ ] `tsc --noEmit` passes ✅