### PR TITLE
feat: admin quick-link from review workspace + simpler sign-out tooltip

### DIFF
--- a/src/app/reviews/[talkId]/page.tsx
+++ b/src/app/reviews/[talkId]/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
 import { StarRating } from '@/src/components/common/StarRating';
 import Modal from '@/src/components/common/Modal';
@@ -19,6 +21,7 @@ import {
   SkipForward,
   Ban,
   ExternalLink,
+  ShieldCheck,
   Users,
 } from 'lucide-react';
 
@@ -46,6 +49,8 @@ type FilterType = 'all' | 'reviewed' | 'pending' | 'skipped';
 export default function ReviewWorkspacePage() {
   const params = useParams<{ talkId: string }>();
   const router = useRouter();
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.role === 'admin';
 
   const [talks, setTalks] = useState<Talk[]>([]);
   const [loading, setLoading] = useState(true);
@@ -374,6 +379,15 @@ export default function ReviewWorkspacePage() {
           </div>
 
           <div className="flex items-center gap-3 shrink-0">
+            {isAdmin && (
+              <Link
+                href={`/admin/submissions/${currentTalk.id}`}
+                className="inline-flex items-center gap-1.5 text-xs font-medium text-[#006B3F] dark:text-emerald-400 hover:underline"
+              >
+                <ShieldCheck className="w-3.5 h-3.5" />
+                <span>Open in Admin</span>
+              </Link>
+            )}
             <a
               href="https://docs.google.com/document/d/1DDoJZz93_n8_YqXCgZoAydPaOi3MQMpKxg0cAqaX-_8/edit?usp=sharing"
               target="_blank"

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -69,18 +69,13 @@ export default function Header({ mounted = true }: HeaderProps) {
               </Link>
             )}
             {session && (
-              <div className="relative group">
-                <button
-                  onClick={() => signOut({ callbackUrl: '/' })}
-                  className={navLink}
-                >
-                  Sign out
-                </button>
-                <div className="absolute right-0 top-full mt-2 w-56 bg-gray-900 text-white rounded-lg px-3 py-2.5 text-xs opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 shadow-lg">
-                  <p className="font-medium truncate">{session.user?.email}</p>
-                  {roles && <p className="text-gray-400 mt-0.5">{roles}</p>}
-                </div>
-              </div>
+              <button
+                onClick={() => signOut({ callbackUrl: '/' })}
+                title={session.user?.email ?? undefined}
+                className={navLink}
+              >
+                Sign out
+              </button>
             )}
             {isInternal && themeMounted && (
               <button


### PR DESCRIPTION
## Summary
- Reviewers who are also admins get an **Open in Admin** link (shield icon) next to "Review Guidelines" in the review workspace toolbar, opening the current talk at `/admin/submissions/[id]`. Gated on `role === 'admin'`, so plain reviewers never see it.
- The sign-out hover tooltip is simplified to a native `title` attribute showing just the email — same mechanism as the light/dark mode toggle. The custom hover card with roles is removed. (Mobile menu inline email/roles block is unchanged.)

## Testing
- `npx tsc --noEmit` passes clean.
- Verified the admin submission detail route uses the same Talk id as the review workspace, so the link lands on the exact talk being reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)