### PR TITLE
CI: deploy to Cloudflare Workers instead of Vercel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,6 @@ name: Deploy CI
 on:
   push:
     branches: [main]
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -12,15 +9,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Vercel CLI
-        run: npm install -g vercel@latest
-      - name: Pull Vercel environment
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
       - name: Run database migrations
-        run: npx prisma@5 migrate deploy
+        # DATABASE_URL is a prisma+postgres:// URL, which prisma migrate (v5)
+        # can't speak directly — tunnel to a local TCP endpoint first.
+        run: |
+          npx @prisma/ppg-tunnel --host 127.0.0.1 --port 5433 &
+          sleep 8
+          DATABASE_URL="postgres://tunnel:tunnel@127.0.0.1:5433/postgres?sslmode=disable" npx prisma migrate deploy
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      - name: Build project
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy to Cloudflare Workers
+        run: npx opennextjs-cloudflare build && npx opennextjs-cloudflare deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: a01b760e5af733b8d91d6ec48514aaa3

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,20 @@ function isAdminPath(pathname: string) {
 // Kept as middleware.ts (not Next 16's proxy.ts): proxy files are forced onto
 // the Node.js runtime, which @opennextjs/cloudflare does not support yet.
 // middleware.ts still compiles for the edge runtime, which Workers requires.
+// Legacy/alias hostnames served by this Worker; 301 everything to the apex.
+const redirectHosts = new Set([
+  'gophers.africa',
+  'www.gophers.africa',
+  'www.gophercon.africa',
+])
+
 export async function middleware(request: NextRequest) {
+  const host = request.headers.get('host') ?? ''
+  if (redirectHosts.has(host)) {
+    const { pathname, search } = request.nextUrl
+    return NextResponse.redirect(new URL(`https://gophercon.africa${pathname}${search}`), 301)
+  }
+
   const token = await getToken({ req: request })
   const { pathname } = request.nextUrl
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,14 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  // gophers.africa + www hostnames are served here too; middleware 301s them
+  // (and www.gophercon.africa) to the apex.
+  "routes": [
+    { "pattern": "gophercon.africa", "custom_domain": true },
+    { "pattern": "www.gophercon.africa", "custom_domain": true },
+    { "pattern": "gophers.africa", "custom_domain": true },
+    { "pattern": "www.gophers.africa", "custom_domain": true }
+  ],
   "observability": {
     "enabled": true
   },


### PR DESCRIPTION
Replaces the Vercel CLI deploy in `Deploy CI` with a Cloudflare Workers deploy, so merges to `main` only deploy to Cloudflare.

- Build + deploy via `opennextjs-cloudflare` with `CLOUDFLARE_API_TOKEN` / account ID env.
- `prisma migrate deploy` now runs through `@prisma/ppg-tunnel` because Prisma 5 can't run migrations over a `prisma+postgres://` URL directly.
- Repo secret `DATABASE_URL` has been updated to the new prisma.io account's URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)